### PR TITLE
Don't show blank taskbar buttons for mnemonic/register tooltips.

### DIFF
--- a/VS/CSHARP/asm-dude-vsix/QuickInfo/AsmQuickInfoController.cs
+++ b/VS/CSHARP/asm-dude-vsix/QuickInfo/AsmQuickInfoController.cs
@@ -270,6 +270,7 @@ namespace AsmDude.QuickInfo
                     WindowStyle = WindowStyle.None,
                     ResizeMode = ResizeMode.NoResize,
                     SizeToContent = SizeToContent.WidthAndHeight,
+                    ShowInTaskbar = false,
                     Left = p.X,
                     Top = p.Y,
                     Content = border


### PR DESCRIPTION
This PR gets rid of this (a blank taskbar button shows up while a tooltip window is around):
![image](https://user-images.githubusercontent.com/731492/57639379-6e82aa00-75b8-11e9-8c95-fcaa792f5c3a.png)
With this you can still see the main window button briefly deactivating when mouseovering the tooltip, but I'm not entirely sure how this is to be fixed in this context (might need to set Owner correctly, but how to get the correct IDE window?)