### PR TITLE
Migrate QuickGraph to QuikGraph.

### DIFF
--- a/VS/CSHARP/asm-sim-lib/DynamicFlow.cs
+++ b/VS/CSHARP/asm-sim-lib/DynamicFlow.cs
@@ -29,7 +29,7 @@ namespace AsmSim
     using System.Text;
     using AsmTools;
     using Microsoft.Z3;
-    using QuickGraph;
+    using QuikGraph;
 
     public class DynamicFlow : IDisposable
     {

--- a/VS/CSHARP/asm-sim-lib/ExecutionTree.cs
+++ b/VS/CSHARP/asm-sim-lib/ExecutionTree.cs
@@ -24,7 +24,7 @@ namespace AsmSim
 {
     using System;
     using System.Collections.Generic;
-    using QuickGraph;
+    using QuikGraph;
 
     public class ExecutionTree : IDisposable
     {

--- a/VS/CSHARP/asm-sim-lib/GraphTools.cs
+++ b/VS/CSHARP/asm-sim-lib/GraphTools.cs
@@ -26,7 +26,7 @@ namespace AsmSim
     using System.Collections.Generic;
     using System.Diagnostics.Contracts;
     using System.Linq;
-    using QuickGraph;
+    using QuikGraph;
 
     public static class GraphTools<Tag>
     {

--- a/VS/CSHARP/asm-sim-lib/StaticFlow.cs
+++ b/VS/CSHARP/asm-sim-lib/StaticFlow.cs
@@ -29,7 +29,7 @@ namespace AsmSim
     using System.Linq;
     using System.Text;
     using AsmTools;
-    using QuickGraph;
+    using QuikGraph;
 
     public class StaticFlow
     {

--- a/VS/CSHARP/asm-sim-lib/asm-sim-lib.csproj
+++ b/VS/CSHARP/asm-sim-lib/asm-sim-lib.csproj
@@ -132,8 +132,8 @@
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers">
       <Version>16.4.16</Version>
     </PackageReference>
-    <PackageReference Include="QuickGraph">
-      <Version>3.6.61119.7</Version>
+    <PackageReference Include="QuikGraph">
+      <Version>2.2.0</Version>
     </PackageReference>
     <PackageReference Include="SmartThreadPool.dll">
       <Version>2.2.6</Version>

--- a/VS/CSHARP/asm-sim-main/DotVisualizer.cs
+++ b/VS/CSHARP/asm-sim-main/DotVisualizer.cs
@@ -27,9 +27,9 @@ namespace AsmSim
     using System.Globalization;
     using System.IO;
     using System.Windows.Forms;
-    using QuickGraph;
-    using QuickGraph.Graphviz;
-    using QuickGraph.Graphviz.Dot;
+    using QuikGraph;
+    using QuikGraph.Graphviz;
+    using QuikGraph.Graphviz.Dot;
 
     public static class DotVisualizer
     {
@@ -94,13 +94,13 @@ namespace AsmSim
             {
                 Value = e.Edge.Tag,
             };
-            e.EdgeFormatter.Label = label;
+            e.EdgeFormat.Label = label;
         }
 
         private static void VizFormatVertex(object sender, FormatVertexEventArgs<string> e)
         {
             Contract.Requires(e != null);
-            e.VertexFormatter.Label = e.Vertex.ToString(CultureInfo.InvariantCulture);
+            e.VertexFormat.Label = e.Vertex.ToString(CultureInfo.InvariantCulture);
         }
 
         private sealed class FileDotEngine : IDotEngine

--- a/VS/CSHARP/asm-sim-main/ProgramZ3.cs
+++ b/VS/CSHARP/asm-sim-main/ProgramZ3.cs
@@ -29,7 +29,7 @@ namespace AsmSim
     using System.Reflection;
     using AsmTools;
     using Microsoft.Z3;
-    using QuickGraph;
+    using QuikGraph;
 
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "<Pending>")]
     internal class AsmSimMain

--- a/VS/CSHARP/asm-sim-main/asm-sim-main.csproj
+++ b/VS/CSHARP/asm-sim-main/asm-sim-main.csproj
@@ -133,6 +133,9 @@
     <PackageReference Include="System.ValueTuple">
       <Version>4.5.0</Version>
     </PackageReference>
+    <PackageReference Include="QuikGraph.Graphviz">
+      <Version>2.2.0</Version>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\asm-tools-lib\asm-tools-lib.csproj">


### PR DESCRIPTION
Hello,

I updated the quite old QuickGraph dependency to QuikGraph.

This library is using modern C# development workflow, have been ported to .NET Core with a wider support in term of targets.
And finally it comes with a huge set of unit tests that has helped to debug and fix a lot of issues.
I also put some effort on the Graphviz module you are using to fix some issues.

Here is the link to the library:
- [QuikGraph](https://github.com/KeRNeLith/QuikGraph)