### PR TITLE
Fix build, add automated build & cleanup dependencies

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -1,0 +1,18 @@
+name: Visual Studio CI Build
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Add msbuild to PATH
+      uses: microsoft/setup-msbuild@v2
+
+    - name: Restore dependencies
+      run: MSBuild.exe VS/AsmDude.sln /t:Restore /m
+  
+    - name: Build
+      run: MSBuild.exe VS/AsmDude.sln /t:Rebuild /m

--- a/VS/CSHARP/asm-annotate/asm-annotate.csproj
+++ b/VS/CSHARP/asm-annotate/asm-annotate.csproj
@@ -2,31 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0-windows8.0</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <RootNamespace>asm_annotate</RootNamespace>
     <Platforms>AnyCPU</Platforms>
-    <SupportedOSPlatformVersion>8.0</SupportedOSPlatformVersion>
     <EnforceCodeStyleInBuild>True</EnforceCodeStyleInBuild>
     <EnableNETAnalyzers>True</EnableNETAnalyzers>
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.4">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.4">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.Composition.Analyzers" Version="1.2.0-beta2" />
-    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.7.30">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="System.Collections.Immutable.Analyzers" Version="1.2.0-beta2" />
-  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\asm-tools-lib\asm-tools-lib.csproj" />

--- a/VS/CSHARP/asm-dude-vsix/asm-dude-vsix.csproj
+++ b/VS/CSHARP/asm-dude-vsix/asm-dude-vsix.csproj
@@ -333,88 +333,12 @@
     </Page>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Community.VisualStudio.Toolkit.15">
-      <Version>15.0.507</Version>
-    </PackageReference>
-    <PackageReference Include="EnvDTE100">
-      <Version>16.10.31320.204</Version>
-    </PackageReference>
-    <PackageReference Include="Extended.Wpf.Toolkit">
-      <Version>4.5.1</Version>
-    </PackageReference>
-    <PackageReference Include="LoadingIndicators.WPF">
-      <Version>0.0.1</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers">
-      <Version>3.3.4</Version>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp">
-      <Version>4.7.0</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.EditorFeatures.Text">
-      <Version>4.7.0</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.Scripting">
-      <Version>4.7.0</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.CoreUtility">
-      <Version>16.11.52</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.Editor">
-      <Version>16.11.52</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.Language">
-      <Version>16.11.52</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.Language.Intellisense">
-      <Version>16.11.52</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.OLE.Interop">
-      <Version>16.10.31320.204</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.Text.Data">
-      <Version>16.11.52</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.Text.Logic">
-      <Version>16.11.52</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.Text.UI">
-      <Version>16.11.52</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.Text.UI.Wpf">
-      <Version>16.11.52</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.TextManager.Interop">
-      <Version>16.10.31320.204</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.Threading">
-      <Version>16.10.56</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.Xaml">
-      <Version>4.0.0.1</Version>
-      <Generator>MSBuild:Compile</Generator>
-      <SubType>Designer</SubType>
-    </PackageReference>
-    <PackageReference Include="QuickGraph">
-      <Version>3.6.61119.7</Version>
-    </PackageReference>
-    <PackageReference Include="SmartThreadPool.dll">
-      <Version>2.3.0</Version>
-    </PackageReference>
-    <PackageReference Include="System.ComponentModel.Composition">
-      <Version>7.0.0</Version>
-    </PackageReference>
-    <PackageReference Include="System.Drawing.Primitives">
-      <Version>4.3.0</Version>
-    </PackageReference>
-    <PackageReference Include="System.Runtime">
-      <Version>4.3.1</Version>
-    </PackageReference>
-    <PackageReference Include="System.Xml.ReaderWriter">
-      <Version>4.3.1</Version>
-    </PackageReference>
+    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.9.*" />
+    <PackageReference Include="Extended.Wpf.Toolkit" Version="4.5.*" />
+    <PackageReference Include="LoadingIndicators.WPF" Version="0.0.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Scripting" Version="4.9.*" />
+    <PackageReference Include="QuickGraph" Version="3.6.*" />
+    <PackageReference Include="SmartThreadPool.dll" Version="2.3.*" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/VS/CSHARP/asm-dude2-ls-lib/LanguageServer.cs
+++ b/VS/CSHARP/asm-dude2-ls-lib/LanguageServer.cs
@@ -381,16 +381,6 @@ namespace AsmDude2LS
 
         private void UpdateFoldingRanges(Uri uri)
         {
-            static string GetCollapsedText(int startPos, string line)
-            {
-                int length = line.Length - startPos;
-                if (length <= 0)
-                {
-                    return "...";
-                }
-                return line.Substring(startPos, length).Trim();
-            }
-
             if (!this.options.CodeFolding_On)
             {
                 return;
@@ -443,8 +433,7 @@ namespace AsmDude2LS
                                 StartCharacter = startCharacter,
                                 EndLine = lineNumber,
                                 EndCharacter = offsetEndRegion + endKeywordLength,
-                                Kind = FoldingRangeKind.Region,
-                                CollapsedText = GetCollapsedText(startCharacter + startKeywordLength + 1, lines[startLine]),
+                                Kind = FoldingRangeKind.Region
                             });
                         }
                     }

--- a/VS/CSHARP/asm-dude2-ls-lib/asm-dude2-ls-lib.csproj
+++ b/VS/CSHARP/asm-dude2-ls-lib/asm-dude2-ls-lib.csproj
@@ -2,7 +2,7 @@
 <Project>
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.props" />
   <PropertyGroup>
-    <TargetFramework>net7.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <SignAssembly>false</SignAssembly>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CA1001,CA1305,CA1307,CA1721,CA1724,CA1801,CA1822,CA2007,CA2213,CS1591,CS1668</NoWarn>
@@ -72,13 +72,8 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0-rc.1.23419.4" />
-    <PackageReference Include="Microsoft.VisualStudio.Language.StandardClassification" Version="17.7.188" />
-	<PackageReference Include="Microsoft.VisualStudio.LanguageServer.Protocol" Version="17.8.9-preview" />
-	<PackageReference Include="Microsoft.VisualStudio.LanguageServer.Protocol.Internal" Version="17.8.9-preview" />
-	<PackageReference Include="Microsoft.VisualStudio.LanguageServer.Protocol.Extensions" Version="17.8.9-preview" />
-	<PackageReference Include="StreamJsonRpc" Version="2.16.36" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Microsoft.VisualStudio.LanguageServer.Protocol.Extensions" Version="17.2.*" />
+    <PackageReference Include="StreamJsonRpc" Version="2.17.*" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\asm-tools-lib\asm-tools-lib.csproj" />

--- a/VS/CSHARP/asm-dude2-ls/asm-dude2-ls.csproj
+++ b/VS/CSHARP/asm-dude2-ls/asm-dude2-ls.csproj
@@ -7,7 +7,7 @@
 	<Description>AsmDude2 Language Server Protocol (LSP) for assembly language</Description>
 	<AssemblyName>AsmDude2.LSP</AssemblyName>
 	<Company></Company>
-	<TargetFramework>net7.0-windows</TargetFramework>
+	<TargetFramework>net8.0-windows</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>dotnet-WindowsService-7b46c878-2e29-4de0-b355-fe97116ed91a</UserSecretsId>
@@ -42,7 +42,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/VS/CSHARP/asm-dude2-vsix/asm-dude2-vsix.csproj
+++ b/VS/CSHARP/asm-dude2-vsix/asm-dude2-vsix.csproj
@@ -110,18 +110,8 @@
 	</ItemGroup>
 	
 	<ItemGroup>
-		<PackageReference Include="Extended.Wpf.Toolkit" Version="4.5.1" />
-		<PackageReference Include="Microsoft.VisualStudio.LanguageServer.Protocol" Version="17.8.9-preview" />
-		<PackageReference Include="Microsoft.VisualStudio.LanguageServer.Protocol.Internal" Version="17.8.9-preview" />
-		<PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.7.37357" />
-		<PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.7.30">
-		  <PrivateAssets>all</PrivateAssets>
-		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-		<PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.7.2196">
-		  <PrivateAssets>all</PrivateAssets>
-		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
+		<PackageReference Include="Extended.Wpf.Toolkit" Version="4.6.*" />
+		<PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.9.*" />
 		<Page Include="OptionsPage\AsmDudeOptionPageUI.xaml">
 		  <Generator>XamlIntelliSenseFileGenerator</Generator>
 		  <CopyToOutputDirectory>Never</CopyToOutputDirectory>
@@ -158,38 +148,7 @@
 	  </None>
 	</ItemGroup>
 
-	<Target Name="IncludeLanguageServers" BeforeTargets="GetVsixSourceItems">
-		<ItemGroup>
-			<Content Include="$(BaseOutputPath)\..\..\asm-dude2-ls\bin\$(Configuration)\net7.0-windows\*.*" Visible="false">
-				<IncludeInVSIX>true</IncludeInVSIX>
-				<VsixSubPath>Server</VsixSubPath>
-			</Content>
-		</ItemGroup>
-		<ItemGroup>
-			<Content Include="$(BaseOutputPath)\..\..\asm-dude2-ls-lib\Resources\*.*" Visible="false">
-				<IncludeInVSIX>true</IncludeInVSIX>
-				<VsixSubPath>Server\Resources</VsixSubPath>
-			</Content>
-		</ItemGroup>
-		<ItemGroup>
-			<Content Include="$(BaseOutputPath)\..\..\asm-dude2-ls-lib\Resources\Performance\*.*" Visible="false">
-				<IncludeInVSIX>true</IncludeInVSIX>
-				<VsixSubPath>Server\Resources\Performance</VsixSubPath>
-			</Content>
-		</ItemGroup>
-	</Target>
-
-	<!-- We shouldn't package the client definition dll with the extension -->
-	<Target Name="RemoveClientDefinition" AfterTargets="GetVsixSourceItems">
-		<ItemGroup>
-			<VsixSourceItem Remove="@(VsixSourceItem)" Condition=" '%(FileName)%(Extension)' == 'Microsoft.VisualStudio.LanguageServer.Client.dll' " />
-		</ItemGroup>
-	</Target>
-
 	<Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
 	<Import Project="$(VSToolsPath)\vssdk\Microsoft.VSSDK.targets" Condition="'$(VSToolsPath)' != ''" />
-	<ItemGroup>
-	  <AdditionalFiles Remove="C:\Users\henkj\.nuget\packages\microsoft.visualstudio.sdk.analyzers\16.10.10\build\AdditionalFiles\BannedSymbols.txt" />
-	</ItemGroup>
 
 </Project>

--- a/VS/CSHARP/asm-irony/asm-irony.csproj
+++ b/VS/CSHARP/asm-irony/asm-irony.csproj
@@ -77,19 +77,8 @@
     <None Include="App.config" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Irony.Interpreter">
-      <Version>0.9.1</Version>
-    </PackageReference>
-    <PackageReference Include="System.ValueTuple">
-      <Version>4.5.0</Version>
-    </PackageReference>
+    <PackageReference Include="Irony.Interpreter" Version="1.5.*" />
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
 </Project>

--- a/VS/CSHARP/asm-sim-lib/asm-sim-lib.csproj
+++ b/VS/CSHARP/asm-sim-lib/asm-sim-lib.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <RootNamespace>asm_sim_lib2</RootNamespace>
 	<PlatformTarget>x64</PlatformTarget>
 	<ImplicitUsings>enable</ImplicitUsings>
@@ -13,8 +13,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Z3" Version="4.12.2" />
-    <PackageReference Include="QuikGraph" Version="2.5.0" />
+    <PackageReference Include="Microsoft.Z3" Version="4.12.*" />
+    <PackageReference Include="QuikGraph" Version="2.5.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/VS/CSHARP/asm-sim-main/asm-sim-main.csproj
+++ b/VS/CSHARP/asm-sim-main/asm-sim-main.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <RootNamespace>asm_sim_main2</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
@@ -11,8 +11,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Z3" Version="4.12.2" />
-    <PackageReference Include="QuikGraph.Graphviz" Version="2.5.0" />
+    <PackageReference Include="Microsoft.Z3" Version="4.12.*" />
+    <PackageReference Include="QuikGraph.Graphviz" Version="2.5.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/VS/CSHARP/asm-sim-tests/asm-sim-tests.csproj
+++ b/VS/CSHARP/asm-sim-tests/asm-sim-tests.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <RootNamespace>asm_sim_tests</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
@@ -11,13 +11,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0-release-23468-02" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
-    <PackageReference Include="coverlet.collector" Version="6.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.*" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.2.*" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.2.*" />
+    <PackageReference Include="coverlet.collector" Version="6.0.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/VS/CSHARP/asm-tools-lib-net48/asm-tools-lib-net48.csproj
+++ b/VS/CSHARP/asm-tools-lib-net48/asm-tools-lib-net48.csproj
@@ -37,45 +37,10 @@
     <RunCodeAnalysis>false</RunCodeAnalysis>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=4.8.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.4.8.0-1.final\lib\netstandard2.0\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.CSharp.Scripting, Version=4.8.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.Scripting.4.8.0-1.final\lib\netstandard2.0\Microsoft.CodeAnalysis.CSharp.Scripting.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.Scripting, Version=4.8.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Scripting.Common.4.8.0-1.final\lib\netstandard2.0\Microsoft.CodeAnalysis.Scripting.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>
-    </Reference>
+    <PackageReference Include="Microsoft.CodeAnalysis.Scripting" Version="4.9.*" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
-    <Reference Include="System.Memory, Version=4.0.1.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Memory.4.5.5\lib\net461\System.Memory.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Numerics" />
-    <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=7.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Runtime.CompilerServices.Unsafe.7.0.0-preview.2.22152.2\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
-    </Reference>
     <Reference Include="System.Runtime.Serialization" />
-    <Reference Include="System.Runtime.Serialization.Primitives, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Runtime.Serialization.Primitives.4.3.0\lib\net46\System.Runtime.Serialization.Primitives.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System.Text.Encoding.CodePages, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Text.Encoding.CodePages.8.0.0-rc.1.23419.4\lib\net462\System.Text.Encoding.CodePages.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
-    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -150,11 +115,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting">
-      <Version>4.7.0</Version>
-    </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/VS/CSHARP/asm-tools-lib/asm-tools-lib.csproj
+++ b/VS/CSHARP/asm-tools-lib/asm-tools-lib.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <RootNamespace>AsmTools</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.7.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Scripting" Version="4.9.*" />
   </ItemGroup>
 
 </Project>

--- a/VS/CSHARP/asm-tools-tests/asm-tools-tests.csproj
+++ b/VS/CSHARP/asm-tools-tests/asm-tools-tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <RootNamespace>asm_tools_tests</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
@@ -11,13 +11,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0-release-23468-02" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
-    <PackageReference Include="coverlet.collector" Version="6.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.*" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.2.*" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.2.*" />
+    <PackageReference Include="coverlet.collector" Version="6.0.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/VS/CSHARP/intel-doc-2-data/intel-doc-2-data.csproj
+++ b/VS/CSHARP/intel-doc-2-data/intel-doc-2-data.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <ApplicationIcon />
     <StartupObject />
   </PropertyGroup>


### PR DESCRIPTION
- The code did not compile due to missing dependencies etc.
- There were a lot of redundancy in the dependencies 
   - e.g. Microsoft.VisualStudio.SDK already pulls a lot of dependencies with it and there is no need to declare them again. 
      - See https://www.nuget.org/packages/Microsoft.VisualStudio.SDK#dependencies-body-tab for more details